### PR TITLE
Add evolutionary antenna simulation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,14 @@ Hopefully I will create compact example with real results and maybe there would 
 
 Wilkinson divider, created in FreeCAD, simulated in OpenEMS, Octave script edited manually. Test run:
 ![](_img/eFieldWilkinsonDivider.gif)
+
+## Evolutionary Simulation
+The `evolution` directory contains a small example showing how OpenEMS can be
+used from Python to iteratively optimise a rectangular patch antenna. The script
+`antenna_evolution.py` calls Octave to run the template `patch_template.m`. The
+antenna parameters are mutated until the average directivity improves by 100%.
+Run the example with:
+```bash
+python3 evolution/antenna_evolution.py
+```
+Octave and OpenEMS need to be installed for the simulation to run.

--- a/evolution/antenna_evolution.py
+++ b/evolution/antenna_evolution.py
@@ -1,0 +1,103 @@
+import os
+import subprocess
+import random
+import statistics
+from tempfile import NamedTemporaryFile
+
+class AntennaSimulator:
+    """Run openEMS simulations using an Octave template."""
+    def __init__(self, template_path):
+        self.template_path = template_path
+
+    def simulate(self, params):
+        """Run the simulation with given parameters and return metrics."""
+        with open(self.template_path, 'r', encoding='utf-8') as f:
+            template = f.read()
+        script = template.format(
+            WIDTH=params['width'],
+            LENGTH=params['length'],
+            FEED_POS=params['feed_pos'],
+            FEED_WIDTH=params['feed_width']
+        )
+        with NamedTemporaryFile('w', suffix='.m', delete=False) as tmp:
+            tmp.write(script)
+            tmp_path = tmp.name
+        try:
+            result = subprocess.run(
+                ['octave', '--quiet', tmp_path],
+                capture_output=True, text=True, check=False
+            )
+        finally:
+            os.remove(tmp_path)
+        directivity = None
+        power = None
+        for line in result.stdout.splitlines():
+            if 'directivity:' in line:
+                try:
+                    directivity = float(line.split('=')[1].split()[0])
+                except (IndexError, ValueError):
+                    pass
+            if 'radiated power:' in line:
+                try:
+                    power = float(line.split('=')[1].split()[0])
+                except (IndexError, ValueError):
+                    pass
+        if directivity is None:
+            raise RuntimeError('Failed to parse simulation output:\n' + result.stdout)
+        return {
+            'directivity': directivity,
+            'power': power,
+            'stdout': result.stdout,
+            'stderr': result.stderr,
+            'returncode': result.returncode,
+        }
+
+def mutate(params, sigma=0.05):
+    """Return a mutated copy of the parameter dictionary."""
+    return {
+        'width': max(1.0, random.gauss(params['width'], params['width'] * sigma)),
+        'length': max(1.0, random.gauss(params['length'], params['length'] * sigma)),
+        'feed_pos': random.gauss(params['feed_pos'], abs(params['feed_pos']) * sigma),
+        'feed_width': max(0.1, random.gauss(params['feed_width'], params['feed_width'] * sigma)),
+    }
+
+def evolve(initial_params, template_path, target_factor=2.0, population=4, max_generations=50):
+    """Simple evolutionary search for improved directivity."""
+    sim = AntennaSimulator(template_path)
+    metrics = sim.simulate(initial_params)
+    baseline = metrics['directivity']
+    best_params = initial_params.copy()
+    best_score = baseline
+    generation = 0
+    avg_score = baseline
+    history = []
+    while avg_score < baseline * target_factor and generation < max_generations:
+        candidates = []
+        for _ in range(population):
+            p = mutate(best_params)
+            m = sim.simulate(p)
+            p['score'] = m['directivity']
+            candidates.append(p)
+        avg_score = statistics.mean(c['score'] for c in candidates)
+        candidates.sort(key=lambda c: c['score'], reverse=True)
+        best_params = candidates[0]
+        best_score = best_params['score']
+        generation += 1
+        history.append({'generation': generation, 'best': best_score, 'average': avg_score})
+    return best_params, history
+
+if __name__ == '__main__':
+    params = {
+        'width': 32.86,
+        'length': 41.37,
+        'feed_pos': -5.5,
+        'feed_width': 2.0,
+    }
+    template = os.path.join(os.path.dirname(__file__), 'patch_template.m')
+    try:
+        best, hist = evolve(params, template)
+        for h in hist:
+            print(f"Generation {h['generation']}: avg={h['average']:.2f} best={h['best']:.2f}")
+        print('Best parameters:', best)
+    except FileNotFoundError:
+        print('Octave not found. Install Octave to run simulations.')

--- a/evolution/patch_template.m
+++ b/evolution/patch_template.m
@@ -1,0 +1,151 @@
+%
+% EXAMPLE / antennas / patch antenna
+%
+% This example demonstrates how to:
+%  - calculate the reflection coefficient of a patch antenna
+% 
+%
+% Tested with
+%  - Matlab 2009b
+%  - Octave 3.3.52
+%  - openEMS v0.0.23
+%
+% (C) 2010,2011 Thorsten Liebig <thorsten.liebig@uni-due.de>
+
+close all
+clear
+clc
+
+%% switches & options...
+postprocessing_only = 0;
+draw_3d_pattern = 0; % this may take a while...
+use_pml = 0;         % use pml boundaries instead of mur
+openEMS_opts = '';
+
+%% setup the simulation
+physical_constants;
+unit = 1e-3; % all length in mm
+
+% width in x-direction
+% length in y-direction
+% main radiation in z-direction
+patch.width  = {WIDTH}; % resonant length
+patch.length = {LENGTH};
+
+substrate.epsR   = 3.38;
+substrate.kappa  = 1e-3 * 2*pi*2.45e9 * EPS0*substrate.epsR;
+substrate.width  = 60;
+substrate.length = 60;
+substrate.thickness = 1.524;
+substrate.cells = 4;
+
+feed.pos = {FEED_POS};
+feed.width = {FEED_WIDTH};
+feed.R = 50; % feed resistance
+
+% size of the simulation box
+SimBox = [100 100 25];
+
+%% prepare simulation folder
+Sim_Path = 'tmp';
+Sim_CSX = 'patch_ant.xml';
+if (postprocessing_only==0)
+    [status, message, messageid] = rmdir( Sim_Path, 's' ); % clear previous directory
+    [status, message, messageid] = mkdir( Sim_Path ); % create empty simulation folder
+end
+
+%% setup FDTD parameter & excitation function
+max_timesteps = 30000;
+min_decrement = 1e-5; % equivalent to -50 dB
+f0 = 0e9; % center frequency
+fc = 3e9; % 20 dB corner frequency (in this case 0 Hz - 3e9 Hz)
+FDTD = InitFDTD( 'NrTS', max_timesteps, 'EndCriteria', min_decrement );
+FDTD = SetGaussExcite( FDTD, f0, fc );
+BC = {'MUR' 'MUR' 'MUR' 'MUR' 'MUR' 'MUR'}; % boundary conditions
+if (use_pml>0)
+    BC = {'PML_8' 'PML_8' 'PML_8' 'PML_8' 'PML_8' 'PML_8'}; % use pml instead of mur
+end
+FDTD = SetBoundaryCond( FDTD, BC );
+
+%% setup CSXCAD geometry & mesh
+% currently, openEMS cannot automatically generate a mesh
+max_res = c0 / (f0+fc) / unit / 20; % cell size: lambda/20
+CSX = InitCSX();
+mesh.x = [-SimBox(1)/2 SimBox(1)/2 -substrate.width/2 substrate.width/2 feed.pos];
+% add patch mesh with 2/3 - 1/3 rule
+mesh.x = [mesh.x -patch.width/2-max_res/2*0.66 -patch.width/2+max_res/2*0.33 patch.width/2+max_res/2*0.66 patch.width/2-max_res/2*0.33];
+mesh.x = SmoothMeshLines( mesh.x, max_res, 1.4); % create a smooth mesh between specified mesh lines
+mesh.y = [-SimBox(2)/2 SimBox(2)/2 -substrate.length/2 substrate.length/2 -feed.width/2 feed.width/2];
+% add patch mesh with 2/3 - 1/3 rule
+mesh.y = [mesh.y -patch.length/2-max_res/2*0.66 -patch.length/2+max_res/2*0.33 patch.length/2+max_res/2*0.66 patch.length/2-max_res/2*0.33];
+mesh.y = SmoothMeshLines( mesh.y, max_res, 1.4 );
+mesh.z = [-SimBox(3)/2 linspace(0,substrate.thickness,substrate.cells) SimBox(3) ];
+mesh.z = SmoothMeshLines( mesh.z, max_res, 1.4 );
+mesh = AddPML( mesh, [8 8 8 8 8 8] ); % add equidistant cells (air around the structure)
+CSX = DefineRectGrid( CSX, unit, mesh );
+
+%% create patch
+CSX = AddMetal( CSX, 'patch' ); % create a perfect electric conductor (PEC)
+start = [-patch.width/2 -patch.length/2 substrate.thickness];
+stop  = [ patch.width/2  patch.length/2 substrate.thickness];
+CSX = AddBox(CSX,'patch',10,start,stop);
+
+%% create substrate
+CSX = AddMaterial( CSX, 'substrate' );
+CSX = SetMaterialProperty( CSX, 'substrate', 'Epsilon', substrate.epsR, 'Kappa', substrate.kappa );
+start = [-substrate.width/2 -substrate.length/2 0];
+stop  = [ substrate.width/2  substrate.length/2 substrate.thickness];
+CSX = AddBox( CSX, 'substrate', 0, start, stop );
+
+%% create ground (same size as substrate)
+CSX = AddMetal( CSX, 'gnd' ); % create a perfect electric conductor (PEC)
+start(3)=0;
+stop(3) =0;
+CSX = AddBox(CSX,'gnd',10,start,stop);
+
+%% apply the excitation & resist as a current source
+start = [feed.pos-.1 -feed.width/2 0];
+stop  = [feed.pos+.1 +feed.width/2 substrate.thickness];
+[CSX] = AddLumpedPort(CSX, 5 ,1 ,feed.R, start, stop, [0 0 1], true);
+
+%% dump magnetic field over the patch antenna
+CSX = AddDump( CSX, 'Ht_', 'DumpType', 1, 'DumpMode', 2); % cell interpolated
+start = [-patch.width -patch.length substrate.thickness+1];
+stop  = [ patch.width  patch.length substrate.thickness+1];
+CSX = AddBox( CSX, 'Ht_', 0, start, stop );
+
+%%nf2ff calc
+[CSX nf2ff] = CreateNF2FFBox(CSX, 'nf2ff', -SimBox/2, SimBox/2);
+
+if (postprocessing_only==0)
+    %% write openEMS compatible xml-file
+    WriteOpenEMS( [Sim_Path '/' Sim_CSX], FDTD, CSX );
+
+    %% show the structure
+%    CSXGeomPlot( [Sim_Path '/' Sim_CSX] );
+
+    % run openEMS
+RunOpenEMS( Sim_Path, Sim_CSX, openEMS_opts );
+end
+
+freq = linspace( max([1e9,f0-fc]), f0+fc, 501 );
+U = ReadUI( {'port_ut1','et'}, 'tmp/', freq ); % time domain/freq domain voltage
+I = ReadUI( 'port_it1', 'tmp/', freq ); % time domain/freq domain current (half time step is corrected)
+
+f_res = f0;
+
+
+% calculate the far field at phi=0 degrees and at phi=90 degrees
+thetaRange = (0:2:359) - 180;
+phiRange = [0 90];
+disp( 'calculating far field at phi=[0 90] deg...' );
+nf2ff = CalcNF2FF(nf2ff, Sim_Path, f_res, thetaRange*pi/180, phiRange*pi/180);
+
+Dlog=10*log10(nf2ff.Dmax);
+
+% display power and directivity
+disp( ['radiated power: Prad = ' num2str(nf2ff.Prad) ' Watt']);
+disp( ['directivity: Dmax = ' num2str(Dlog) ' dBi'] );
+
+
+


### PR DESCRIPTION
## Summary
- add a Python-based antenna evolution demo under `evolution/`
- include an OpenEMS template script to run simulations
- document new example in the project README

## Testing
- `python3 -m py_compile evolution/antenna_evolution.py`

------
https://chatgpt.com/codex/tasks/task_e_683fdcab04088328a419435bd2084fd3