### PR TITLE
Add dynamic openEMS path setup

### DIFF
--- a/Patch Antenna 0/Patch_Antenna.m
+++ b/Patch Antenna 0/Patch_Antenna.m
@@ -11,7 +11,8 @@
 %  - openEMS v0.0.23
 %
 % (C) 2010,2011 Thorsten Liebig <thorsten.liebig@uni-due.de>
-addpath('C:/Users/H364387/Downloads/openEMS/matlab');
+% Add openEMS path using environment variable OPENEMS_HOME
+run(fullfile(fileparts(mfilename(''fullpath'')), '..', 'setup_openems.m'));
 
 close all
 clear

--- a/Patch Antenna Rectangular/_antenna_8_model.m
+++ b/Patch Antenna Rectangular/_antenna_8_model.m
@@ -11,7 +11,8 @@
 %  - openEMS v0.0.23
 %
 % (C) 2010,2011 Thorsten Liebig <thorsten.liebig@uni-due.de>
-addpath('C:/Users/H364387/Downloads/openEMS/matlab');
+% Add openEMS path using environment variable OPENEMS_HOME
+run(fullfile(fileparts(mfilename(''fullpath'')), '..', 'setup_openems.m'));
 
 close all
 clear

--- a/README.md
+++ b/README.md
@@ -4,5 +4,13 @@ Because I know how to design antennas (or at least I thinks so) I know that for 
 For now this repository contains just some experimental files which were created on the way how I learned how to simulate basic patch antenna shapes and how to create design in FreeCAD and import it into openEMS.
 Hopefully I will create compact example with real results and maybe there would be simple way to create some macro for FreeCAD to generate openEMS simulation file from GUI.
 
+## openEMS Path Configuration
+
+Each example script requires access to the openEMS MATLAB/Octave interface.
+To avoid hard coded paths, the function `setup_openems.m` adds this
+directory to the MATLAB/Octave path based on the `OPENEMS_HOME`
+environment variable. Set this variable to your openEMS installation
+directory before running any of the provided scripts.
+
 Wilkinson divider, created in FreeCAD, simulated in OpenEMS, Octave script edited manually. Test run:
 ![](_img/eFieldWilkinsonDivider.gif)

--- a/coax_cable_0_example/Coax.m
+++ b/coax_cable_0_example/Coax.m
@@ -12,7 +12,8 @@
 %  - openEMS v0.0.17
 %
 % (C) 2010 Thorsten Liebig <thorsten.liebig@uni-due.de>
-addpath('C:/Users/H364387/Downloads/openEMS/matlab');
+% Add openEMS path using environment variable OPENEMS_HOME
+run(fullfile(fileparts(mfilename(''fullpath'')), '..', 'setup_openems.m'));
 
 close all
 clear

--- a/coax_cable_1/GenerateGeometryOctave.m
+++ b/coax_cable_1/GenerateGeometryOctave.m
@@ -53,7 +53,7 @@ xmlOutput = "";
 %  Generate start of file
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-xmlOutput = [xmlOutput 'addpath(''C:/Users/H364387/Downloads/openEMS/matlab'');' "\n"];
+xmlOutput = [xmlOutput 'run(fullfile(fileparts(mfilename(''fullpath'')), ''..'', ''setup_openems.m''));' "\n"];
 xmlOutput = [xmlOutput 'close all' "\n"];
 xmlOutput = [xmlOutput 'clear' "\n"];
 xmlOutput = [xmlOutput 'clc' "\n"];

--- a/coax_cable_1/tmp/model.m
+++ b/coax_cable_1/tmp/model.m
@@ -1,4 +1,5 @@
-addpath('C:/Users/H364387/Downloads/openEMS/matlab');
+% Add openEMS path using environment variable OPENEMS_HOME
+run(fullfile(fileparts(mfilename(''fullpath'')), '..', '..', 'setup_openems.m'));
 close all
 clear
 clc

--- a/setup_openems.m
+++ b/setup_openems.m
@@ -1,0 +1,14 @@
+function setup_openems()
+%SETUP_OPENEMS Add openEMS MATLAB/Octave path using OPENEMS_HOME
+%   This function adds the openEMS matlab directory to the current path.
+%   The path is taken from the OPENEMS_HOME environment variable. If the
+%   variable is not defined, a warning is displayed and no path is added.
+
+openems_home = getenv('OPENEMS_HOME');
+if isempty(openems_home)
+    warning('OPENEMS_HOME environment variable not set. Please set it to the openEMS installation directory.');
+else
+    addpath(fullfile(openems_home, 'matlab'));
+end
+end
+


### PR DESCRIPTION
## Summary
- add `setup_openems.m` for portable openEMS path setup using `OPENEMS_HOME`
- update example scripts to call `setup_openems.m`
- document the new environment variable in README

## Testing
- `octave -qf --eval "setup_openems"`

------
https://chatgpt.com/codex/tasks/task_e_683ff36f4a8883288800a1670a0666e0