### PR TITLE
Add progress details to GA logger scripts

### DIFF
--- a/ga_message.py
+++ b/ga_message.py
@@ -1,0 +1,20 @@
+import random
+
+def run_sim(num_generations=1000):
+    fitness = 1.0
+    start_fitness = fitness
+    prev_fitness = fitness
+    for gen in range(1, num_generations+1):
+        # simulate improvement
+        fitness += random.uniform(-0.01, 0.02)
+        if gen % 100 == 0:
+            overall_change = 100 * (fitness - start_fitness) / start_fitness
+            interval_change = 100 * (fitness - prev_fitness) / prev_fitness
+            print(
+                f"Generation {gen}: overall change {overall_change:.2f}%, "
+                f"last 100 generations {interval_change:.2f}%"
+            )
+            prev_fitness = fitness
+
+if __name__ == "__main__":
+    run_sim()

--- a/progress_logger.m
+++ b/progress_logger.m
@@ -1,0 +1,16 @@
+num_generations = 1000;
+fitness = 1.0;
+start_fitness = fitness;
+prev_fitness = fitness;
+for gen = 1:num_generations
+    % simulate some random fitness improvement
+    new_fitness = fitness + 0.01*randn();
+    fitness = new_fitness;
+    if mod(gen, 100) == 0
+        overall_change = 100 * (fitness - start_fitness) / start_fitness;
+        interval_change = 100 * (fitness - prev_fitness) / prev_fitness;
+        fprintf('Generation %d: overall change %.2f%%, last 100 generations %.2f%%\n', ...
+                gen, overall_change, interval_change);
+        prev_fitness = fitness;
+    end
+end


### PR DESCRIPTION
## Summary
- update `ga_message.py` to report overall and last-100-generation fitness change
- update Octave `progress_logger.m` for the same

## Testing
- `python3 ga_message.py | head -n 5`
- `octave --quiet progress_logger.m | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_6841f2e7998c8328a58b3d9a5033727c